### PR TITLE
setup.cfg: remove wheel dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 packages = executing
 zip_safe = False
 include_package_data = True
-setup_requires = setuptools; wheel; setuptools_scm[toml]
+setup_requires = setuptools; setuptools_scm[toml]
 
 [coverage:run]
 relative_files = True


### PR DESCRIPTION
This shouldn't be a hard dependency since it's required only
when building binary wheels.

Signed-off-by: Asaf Kahlon <asafka7@gmail.com>