### PR TITLE
Replace deprecated threading aliases

### DIFF
--- a/tests/sample_results/2.7.json
+++ b/tests/sample_results/2.7.json
@@ -14400,15 +14400,15 @@
         ], 
         [
             "LOAD_GLOBAL", 
-            "currentThread"
+            "current_thread"
         ], 
         [
             "CALL_FUNCTION", 
-            "currentThread()"
+            "current_thread()"
         ], 
         [
             "LOAD_ATTR", 
-            "currentThread().ident"
+            "current_thread().ident"
         ], 
         [
             "LOAD_DEREF", 
@@ -14416,7 +14416,7 @@
         ], 
         [
             "CALL_FUNCTION", 
-            "thread_proxies.get(currentThread().ident,\n                                  original)"
+            "thread_proxies.get(current_thread().ident,\n                                  original)"
         ], 
         [
             "LOAD_FAST", 
@@ -14436,15 +14436,15 @@
         ], 
         [
             "LOAD_GLOBAL", 
-            "currentThread"
+            "current_thread"
         ], 
         [
             "CALL_FUNCTION", 
-            "currentThread()"
+            "current_thread()"
         ], 
         [
             "LOAD_ATTR", 
-            "currentThread().ident"
+            "current_thread().ident"
         ], 
         [
             "LOAD_GLOBAL", 

--- a/tests/sample_results/3.10.json
+++ b/tests/sample_results/3.10.json
@@ -14356,15 +14356,15 @@
         ],
         [
             "LOAD_GLOBAL",
-            "currentThread"
+            "current_thread"
         ],
         [
             "CALL_FUNCTION",
-            "currentThread()"
+            "current_thread()"
         ],
         [
             "LOAD_ATTR",
-            "currentThread().ident"
+            "current_thread().ident"
         ],
         [
             "LOAD_DEREF",
@@ -14372,7 +14372,7 @@
         ],
         [
             "CALL_METHOD",
-            "thread_proxies.get(currentThread().ident,\n                                  original)"
+            "thread_proxies.get(current_thread().ident,\n                                  original)"
         ],
         [
             "LOAD_FAST",
@@ -14392,15 +14392,15 @@
         ],
         [
             "LOAD_GLOBAL",
-            "currentThread"
+            "current_thread"
         ],
         [
             "CALL_FUNCTION",
-            "currentThread()"
+            "current_thread()"
         ],
         [
             "LOAD_ATTR",
-            "currentThread().ident"
+            "current_thread().ident"
         ],
         [
             "LOAD_GLOBAL",

--- a/tests/sample_results/3.4.json
+++ b/tests/sample_results/3.4.json
@@ -14244,15 +14244,15 @@
         ],
         [
             "LOAD_GLOBAL",
-            "currentThread"
+            "current_thread"
         ],
         [
             "CALL_FUNCTION",
-            "currentThread()"
+            "current_thread()"
         ],
         [
             "LOAD_ATTR",
-            "currentThread().ident"
+            "current_thread().ident"
         ],
         [
             "LOAD_DEREF",
@@ -14260,7 +14260,7 @@
         ],
         [
             "CALL_FUNCTION",
-            "thread_proxies.get(currentThread().ident,\n                                  original)"
+            "thread_proxies.get(current_thread().ident,\n                                  original)"
         ],
         [
             "LOAD_FAST",
@@ -14280,15 +14280,15 @@
         ],
         [
             "LOAD_GLOBAL",
-            "currentThread"
+            "current_thread"
         ],
         [
             "CALL_FUNCTION",
-            "currentThread()"
+            "current_thread()"
         ],
         [
             "LOAD_ATTR",
-            "currentThread().ident"
+            "current_thread().ident"
         ],
         [
             "LOAD_GLOBAL",

--- a/tests/sample_results/3.5.json
+++ b/tests/sample_results/3.5.json
@@ -14244,15 +14244,15 @@
         ],
         [
             "LOAD_GLOBAL",
-            "currentThread"
+            "current_thread"
         ],
         [
             "CALL_FUNCTION",
-            "currentThread()"
+            "current_thread()"
         ],
         [
             "LOAD_ATTR",
-            "currentThread().ident"
+            "current_thread().ident"
         ],
         [
             "LOAD_DEREF",
@@ -14260,7 +14260,7 @@
         ],
         [
             "CALL_FUNCTION",
-            "thread_proxies.get(currentThread().ident,\n                                  original)"
+            "thread_proxies.get(current_thread().ident,\n                                  original)"
         ],
         [
             "LOAD_FAST",
@@ -14280,15 +14280,15 @@
         ],
         [
             "LOAD_GLOBAL",
-            "currentThread"
+            "current_thread"
         ],
         [
             "CALL_FUNCTION",
-            "currentThread()"
+            "current_thread()"
         ],
         [
             "LOAD_ATTR",
-            "currentThread().ident"
+            "current_thread().ident"
         ],
         [
             "LOAD_GLOBAL",

--- a/tests/sample_results/3.6.json
+++ b/tests/sample_results/3.6.json
@@ -14244,15 +14244,15 @@
         ],
         [
             "LOAD_GLOBAL",
-            "currentThread"
+            "current_thread"
         ],
         [
             "CALL_FUNCTION",
-            "currentThread()"
+            "current_thread()"
         ],
         [
             "LOAD_ATTR",
-            "currentThread().ident"
+            "current_thread().ident"
         ],
         [
             "LOAD_DEREF",
@@ -14260,7 +14260,7 @@
         ],
         [
             "CALL_FUNCTION",
-            "thread_proxies.get(currentThread().ident,\n                                  original)"
+            "thread_proxies.get(current_thread().ident,\n                                  original)"
         ],
         [
             "LOAD_FAST",
@@ -14280,15 +14280,15 @@
         ],
         [
             "LOAD_GLOBAL",
-            "currentThread"
+            "current_thread"
         ],
         [
             "CALL_FUNCTION",
-            "currentThread()"
+            "current_thread()"
         ],
         [
             "LOAD_ATTR",
-            "currentThread().ident"
+            "current_thread().ident"
         ],
         [
             "LOAD_GLOBAL",

--- a/tests/sample_results/3.7.json
+++ b/tests/sample_results/3.7.json
@@ -14216,15 +14216,15 @@
         ],
         [
             "LOAD_GLOBAL",
-            "currentThread"
+            "current_thread"
         ],
         [
             "CALL_FUNCTION",
-            "currentThread()"
+            "current_thread()"
         ],
         [
             "LOAD_ATTR",
-            "currentThread().ident"
+            "current_thread().ident"
         ],
         [
             "LOAD_DEREF",
@@ -14232,7 +14232,7 @@
         ],
         [
             "CALL_METHOD",
-            "thread_proxies.get(currentThread().ident,\n                                  original)"
+            "thread_proxies.get(current_thread().ident,\n                                  original)"
         ],
         [
             "LOAD_FAST",
@@ -14252,15 +14252,15 @@
         ],
         [
             "LOAD_GLOBAL",
-            "currentThread"
+            "current_thread"
         ],
         [
             "CALL_FUNCTION",
-            "currentThread()"
+            "current_thread()"
         ],
         [
             "LOAD_ATTR",
-            "currentThread().ident"
+            "current_thread().ident"
         ],
         [
             "LOAD_GLOBAL",

--- a/tests/sample_results/3.8.json
+++ b/tests/sample_results/3.8.json
@@ -14216,15 +14216,15 @@
         ],
         [
             "LOAD_GLOBAL",
-            "currentThread"
+            "current_thread"
         ],
         [
             "CALL_FUNCTION",
-            "currentThread()"
+            "current_thread()"
         ],
         [
             "LOAD_ATTR",
-            "currentThread().ident"
+            "current_thread().ident"
         ],
         [
             "LOAD_DEREF",
@@ -14232,7 +14232,7 @@
         ],
         [
             "CALL_METHOD",
-            "thread_proxies.get(currentThread().ident,\n                                  original)"
+            "thread_proxies.get(current_thread().ident,\n                                  original)"
         ],
         [
             "LOAD_FAST",
@@ -14252,15 +14252,15 @@
         ],
         [
             "LOAD_GLOBAL",
-            "currentThread"
+            "current_thread"
         ],
         [
             "CALL_FUNCTION",
-            "currentThread()"
+            "current_thread()"
         ],
         [
             "LOAD_ATTR",
-            "currentThread().ident"
+            "current_thread().ident"
         ],
         [
             "LOAD_GLOBAL",

--- a/tests/sample_results/3.9.json
+++ b/tests/sample_results/3.9.json
@@ -14272,15 +14272,15 @@
         ],
         [
             "LOAD_GLOBAL",
-            "currentThread"
+            "current_thread"
         ],
         [
             "CALL_FUNCTION",
-            "currentThread()"
+            "current_thread()"
         ],
         [
             "LOAD_ATTR",
-            "currentThread().ident"
+            "current_thread().ident"
         ],
         [
             "LOAD_DEREF",
@@ -14288,7 +14288,7 @@
         ],
         [
             "CALL_METHOD",
-            "thread_proxies.get(currentThread().ident,\n                                  original)"
+            "thread_proxies.get(current_thread().ident,\n                                  original)"
         ],
         [
             "LOAD_FAST",
@@ -14308,15 +14308,15 @@
         ],
         [
             "LOAD_GLOBAL",
-            "currentThread"
+            "current_thread"
         ],
         [
             "CALL_FUNCTION",
-            "currentThread()"
+            "current_thread()"
         ],
         [
             "LOAD_ATTR",
-            "currentThread().ident"
+            "current_thread().ident"
         ],
         [
             "LOAD_GLOBAL",

--- a/tests/sample_results/pypy2.7.json
+++ b/tests/sample_results/pypy2.7.json
@@ -14372,15 +14372,15 @@
         ], 
         [
             "LOAD_GLOBAL", 
-            "currentThread"
+            "current_thread"
         ], 
         [
             "CALL_FUNCTION", 
-            "currentThread()"
+            "current_thread()"
         ], 
         [
             "LOAD_ATTR", 
-            "currentThread().ident"
+            "current_thread().ident"
         ], 
         [
             "LOAD_DEREF", 
@@ -14388,7 +14388,7 @@
         ], 
         [
             "CALL_METHOD", 
-            "thread_proxies.get(currentThread().ident,\n                                  original)"
+            "thread_proxies.get(current_thread().ident,\n                                  original)"
         ], 
         [
             "LOAD_FAST", 
@@ -14408,15 +14408,15 @@
         ], 
         [
             "LOAD_GLOBAL", 
-            "currentThread"
+            "current_thread"
         ], 
         [
             "CALL_FUNCTION", 
-            "currentThread()"
+            "current_thread()"
         ], 
         [
             "LOAD_ATTR", 
-            "currentThread().ident"
+            "current_thread().ident"
         ], 
         [
             "LOAD_GLOBAL", 

--- a/tests/sample_results/pypy3.5.json
+++ b/tests/sample_results/pypy3.5.json
@@ -14216,15 +14216,15 @@
         ],
         [
             "LOAD_GLOBAL",
-            "currentThread"
+            "current_thread"
         ],
         [
             "CALL_FUNCTION",
-            "currentThread()"
+            "current_thread()"
         ],
         [
             "LOAD_ATTR",
-            "currentThread().ident"
+            "current_thread().ident"
         ],
         [
             "LOAD_DEREF",
@@ -14232,7 +14232,7 @@
         ],
         [
             "CALL_METHOD",
-            "thread_proxies.get(currentThread().ident,\n                                  original)"
+            "thread_proxies.get(current_thread().ident,\n                                  original)"
         ],
         [
             "LOAD_FAST",
@@ -14252,15 +14252,15 @@
         ],
         [
             "LOAD_GLOBAL",
-            "currentThread"
+            "current_thread"
         ],
         [
             "CALL_FUNCTION",
-            "currentThread()"
+            "current_thread()"
         ],
         [
             "LOAD_ATTR",
-            "currentThread().ident"
+            "current_thread().ident"
         ],
         [
             "LOAD_GLOBAL",

--- a/tests/sample_results/pypy3.6.json
+++ b/tests/sample_results/pypy3.6.json
@@ -14216,15 +14216,15 @@
         ],
         [
             "LOAD_GLOBAL",
-            "currentThread"
+            "current_thread"
         ],
         [
             "CALL_FUNCTION",
-            "currentThread()"
+            "current_thread()"
         ],
         [
             "LOAD_ATTR",
-            "currentThread().ident"
+            "current_thread().ident"
         ],
         [
             "LOAD_DEREF",
@@ -14232,7 +14232,7 @@
         ],
         [
             "CALL_METHOD",
-            "thread_proxies.get(currentThread().ident,\n                                  original)"
+            "thread_proxies.get(current_thread().ident,\n                                  original)"
         ],
         [
             "LOAD_FAST",
@@ -14252,15 +14252,15 @@
         ],
         [
             "LOAD_GLOBAL",
-            "currentThread"
+            "current_thread"
         ],
         [
             "CALL_FUNCTION",
-            "currentThread()"
+            "current_thread()"
         ],
         [
             "LOAD_ATTR",
-            "currentThread().ident"
+            "current_thread().ident"
         ],
         [
             "LOAD_GLOBAL",

--- a/tests/samples/ipython.py
+++ b/tests/samples/ipython.py
@@ -2,7 +2,7 @@ import inspect
 import socket
 import sys
 from io import BytesIO, StringIO
-from threading import currentThread, Thread
+from threading import current_thread, Thread
 from uuid import uuid4
 
 from IPython.core.display import HTML, display
@@ -27,7 +27,7 @@ def stream_proxy(original):
             if frame.f_code == ThreadingMixIn.process_request_thread.__code__:
                 return fake_stream()
             frame = frame.f_back
-        return thread_proxies.get(currentThread().ident,
+        return thread_proxies.get(current_thread().ident,
                                   original)
 
     return LocalProxy(p)
@@ -39,7 +39,7 @@ sys.stdout = stream_proxy(sys.stdout)
 
 def run_server(port, bind_host, show_server_output):
     if not show_server_output:
-        thread_proxies[currentThread().ident] = fake_stream()
+        thread_proxies[current_thread().ident] = fake_stream()
     try:
         server.app.run(
             debug=True,


### PR DESCRIPTION
These camelCase aliases were deprecated in Python 3.10 (October 2021).

Replace with the snake_case versions, added in Python 2.6 (October 2008).

* https://docs.python.org/3.12/whatsnew/3.10.html#deprecated
* https://github.com/python/cpython/pull/25174
