### PR TITLE
Always check linecache

### DIFF
--- a/executing/executing.py
+++ b/executing/executing.py
@@ -447,22 +447,6 @@ class Source(object):
         return self._qualnames.get((code.co_name, code.co_firstlineno), code.co_name)
 
 
-if PY3:
-    from importlib.abc import MetaPathFinder
-
-    class ReloadCacheFinder(MetaPathFinder):
-        def find_spec(self, fullname, path, target=None):
-            # Based on https://github.com/ipython/ipython/issues/13598#issuecomment-1207869067
-            # to fix that issue.
-            # `target` should be a module (rather than None) if and only if the module is being reloaded.
-            filename = getattr(target, "__file__", None)
-            if not filename:
-                return
-            linecache.checkcache(filename)
-
-    sys.meta_path.insert(0, ReloadCacheFinder())
-
-
 class Executing(object):
     """
     Information about the operation a frame is currently executing.

--- a/executing/executing.py
+++ b/executing/executing.py
@@ -251,19 +251,11 @@ class Source(object):
         if isinstance(filename, Path):
             filename = str(filename)
 
-        source_cache = cls._class_local('__source_cache', {})
-        if use_cache:
-            try:
-                return source_cache[filename]
-            except KeyError:
-                pass
-
         if not use_cache:
             linecache.checkcache(filename)
 
         lines = tuple(linecache.getlines(filename, module_globals))
-        result = source_cache[filename] = cls._for_filename_and_lines(filename, lines)
-        return result
+        return cls._for_filename_and_lines(filename, lines)
 
     @classmethod
     def _for_filename_and_lines(cls, filename, lines):

--- a/executing/executing.py
+++ b/executing/executing.py
@@ -451,11 +451,7 @@ if PY3:
             filename = getattr(target, "__file__", None)
             if not filename:
                 return
-            # Clear any cached data for this filename.
             linecache.checkcache(filename)
-            for source_class in all_subclasses(Source):
-                source_cache = source_class._class_local("__source_cache", {})
-                source_cache.pop(filename, None)
 
     sys.meta_path.insert(0, ReloadCacheFinder())
 
@@ -1133,12 +1129,3 @@ def node_linenos(node):
             linenos = [node.lineno]
         for lineno in linenos:
             yield lineno
-
-
-def all_subclasses(cls):
-    """
-    Returns a set of all subclasses of a given class, including the class itself,
-    and all direct and indirect descendants.
-    """
-    direct = set(cls.__subclasses__())
-    return {cls} | {s for c in direct for s in all_subclasses(c)}

--- a/executing/executing.py
+++ b/executing/executing.py
@@ -251,10 +251,17 @@ class Source(object):
         if isinstance(filename, Path):
             filename = str(filename)
 
-        if not use_cache:
-            linecache.checkcache(filename)
+        def get_lines():
+            return linecache.getlines(filename, module_globals)
 
-        lines = tuple(linecache.getlines(filename, module_globals))
+        entry = linecache.cache.get(filename)
+        linecache.checkcache(filename)
+        lines = get_lines()
+        if entry is not None and not lines:
+            linecache.cache[filename] = entry
+            lines = get_lines()
+
+        lines = tuple(lines)
         return cls._for_filename_and_lines(filename, lines)
 
     @classmethod

--- a/executing/executing.py
+++ b/executing/executing.py
@@ -336,9 +336,7 @@ class Source(object):
                     assert_(new_stmts <= stmts)
                     stmts = new_stmts
 
-                args = source, node, stmts, decorator
-
-            executing_cache[key] = args
+            executing_cache[key] = args = source, node, stmts, decorator
 
         return Executing(frame, *args)
 

--- a/executing/executing.py
+++ b/executing/executing.py
@@ -259,10 +259,15 @@ class Source(object):
         def get_lines():
             return linecache.getlines(filename, module_globals)
 
+        # Save the current linecache entry, then ensure the cache is up to date.
         entry = linecache.cache.get(filename)
         linecache.checkcache(filename)
         lines = get_lines()
         if entry is not None and not lines:
+            # There was an entry, checkcache removed it, and nothing replaced it.
+            # This means the file wasn't simply changed (because the `lines` wouldn't be empty)
+            # but rather the file was found not to exist, probably because `filename` was fake.
+            # Restore the original entry so that we still have something.
             linecache.cache[filename] = entry
             lines = get_lines()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
 packages = executing

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -243,6 +243,19 @@ class TestStuff(unittest.TestCase):
                 self.assertIs(node, new_node)
         self.assertLess(time.time() - start, 1)
 
+    def test_many_source_for_filename_calls(self):
+        source = None
+        start = time.time()
+        for i in range(10000):
+            new_source = Source.for_filename(__file__)
+            if source is None:
+                source = new_source
+                self.assertGreater(len(source.lines), 700)
+                self.assertGreater(len(source.text), 7000)
+            else:
+                self.assertIs(source, new_source)
+        self.assertLess(time.time() - start, 1)
+
     def test_decode_source(self):
         def check(source, encoding, exception=None, matches=True):
             encoded = source.encode(encoding)

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -1,12 +1,15 @@
+import inspect
 import linecache
 import os
 import sys
 from time import sleep
 
+import pytest
 from littleutils import SimpleNamespace
 
-from executing import Source
+from executing import Source, NotOneValueFound
 from executing.executing import is_ipython_cell_code, attr_names_match
+import executing.executing
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
@@ -108,3 +111,15 @@ def check_manual_linecache(filename):
     source = Source.for_filename(filename)
     assert linecache.cache[filename] == entry
     assert source.text == text
+
+
+def test_exception_catching():
+    executing.executing.TESTING = True
+    with pytest.raises(NotOneValueFound):
+        assert Source.executing(inspect.currentframe()).node is None
+
+    executing.executing.TESTING = False
+    try:
+        assert Source.executing(inspect.currentframe()).node is None
+    finally:
+        executing.executing.TESTING = True

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -107,10 +107,4 @@ def check_source_reload(tmpdir, SourceClass):
     with path.open("w") as f:
         f.write("2\n")
     source = SourceClass.for_filename(path)
-    # Since the module wasn't reloaded, the text hasn't been updated.
-    assert source.text == "1\n"
-
-    # Reload the module. This should update the text.
-    importlib.reload(mod)
-    source = SourceClass.for_filename(path)
     assert source.text == "2\n"

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -6,7 +6,7 @@ from time import sleep
 from littleutils import SimpleNamespace
 
 from executing import Source
-from executing.executing import is_ipython_cell_code, attr_names_match, all_subclasses, PY3
+from executing.executing import is_ipython_cell_code, attr_names_match, PY3
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
@@ -69,10 +69,6 @@ class MySource(Source):
 
 class MySource2(MySource):
     pass
-
-
-def test_all_subclasses():
-    assert all_subclasses(Source) == {Source, MySource, MySource2}
 
 
 def test_source_reload(tmpdir):

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -123,3 +123,24 @@ def test_exception_catching():
         assert Source.executing(inspect.currentframe()).node is None
     finally:
         executing.executing.TESTING = True
+
+
+def test_bad_linecache():
+    fake_text = "foo bar baz"
+    text = """
+import executing
+import inspect
+
+frame = inspect.currentframe()
+ex = executing.Source.executing(frame)
+assert ex.node is None
+assert ex.statements is None
+assert ex.decorator is None
+assert ex.frame is frame
+assert ex.source.tree is None
+assert ex.source.text == %r
+""" % fake_text
+    filename = "<test_bad_linecache>"
+    code = compile(text, filename, "exec")
+    linecache.cache[filename] = (len(fake_text), 0, fake_text.splitlines(True), filename)
+    exec(code)

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -1,4 +1,3 @@
-import importlib
 import os
 import sys
 from time import sleep
@@ -6,7 +5,7 @@ from time import sleep
 from littleutils import SimpleNamespace
 
 from executing import Source
-from executing.executing import is_ipython_cell_code, attr_names_match, PY3
+from executing.executing import is_ipython_cell_code, attr_names_match
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
@@ -63,48 +62,19 @@ def test_attr_names_match():
     assert not attr_names_match("__foo", "_Class_foo")
 
 
-class MySource(Source):
-    pass
-
-
-class MySource2(MySource):
-    pass
-
-
 def test_source_reload(tmpdir):
-    if not PY3:
-        return
-
-    from executing.executing import ReloadCacheFinder
-    assert sum(isinstance(x, ReloadCacheFinder) for x in sys.meta_path) == 1
-
-    check_source_reload(tmpdir, Source)
-    check_source_reload(tmpdir, MySource)
-    check_source_reload(tmpdir, MySource2)
-
-
-def check_source_reload(tmpdir, SourceClass):
-    from pathlib import Path
-
-    modname = "test_tmp_module_" + SourceClass.__name__
-    path = Path(str(tmpdir)) / ("%s.py" % modname)
-    with path.open("w") as f:
+    path = str(tmpdir.join('foo.py'))
+    with open(path, "w") as f:
         f.write("1\n")
 
-    sys.path.append(str(tmpdir))
-    mod = importlib.import_module(modname)
-    # ReloadCacheFinder uses __file__ so it needs to be the same
-    # as what we pass to Source.for_filename here.
-    assert mod.__file__ == str(path)
-
     # Initial sanity check.
-    source = SourceClass.for_filename(path)
+    source = Source.for_filename(path)
     assert source.text == "1\n"
 
     # Wait a little before changing the file so that the mtime is different
     # so that linecache.checkcache() notices.
     sleep(0.01)
-    with path.open("w") as f:
+    with open(path, "w") as f:
         f.write("2\n")
-    source = SourceClass.for_filename(path)
+    source = Source.for_filename(path)
     assert source.text == "2\n"


### PR DESCRIPTION
Fixes:

- https://github.com/alexmojaki/stack_data/issues/38
- https://github.com/ipython/ipython/issues/13598
- https://github.com/ipython/ipython/issues/13586

This ensures that `Source.for_filename` always calls `linecache.checkcache` so that outdated entries are purged and the `Source` reflects the latest content of the file. It's more robust than #45 as it doesn't depend on `sys.meta_path` or even modules being reloaded.

Code elsewhere that pops entries from `__source_cache` is no longer needed, but is harmless and will keep things working with older versions of executing.

If `linecache.checkcache` removes an entry and `linecache.getlines` doesn't create a new one, then the original is restored. This means that code which directly inserts entries into `linecache.cache` to avoid the file system is still safe from `linecache.checkcache` aggressively removing entries for fake filenames.