### PR TITLE
Use extras instead of .[tests] for tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,7 @@ envlist = py27,py34,py35,py36,py37,py38,py39,py310,py311,pypy2,pypy35,pypy36
 commands =
     python tests/test_main.py
     pytest tests/test_pytest.py
-deps =
-    .[tests]
+extras = tests
 passenv = 
     FIX_EXECUTING_TESTS
     ADD_EXECUTING_TESTS


### PR DESCRIPTION
It seems more readable and if tox has a specific config for this, why not use it?