### PR TITLE
Speedup parsing of really-long files.

### DIFF
--- a/executing/executing.py
+++ b/executing/executing.py
@@ -277,7 +277,7 @@ class Source(object):
             lines = [line.decode(encoding) for line in lines]
 
         self.text = text
-        self.lines = [line.rstrip('\r\n') for line in lines]
+        self.lines = text.splitlines()
 
         if sys.version_info[0] == 3:
             ast_text = text

--- a/executing/executing.py
+++ b/executing/executing.py
@@ -1304,7 +1304,7 @@ def node_minmax(node):
         linenos = [] # type: Sequence[int]
         if hasattr(node, "end_lineno") and isinstance(node, ast.expr):
             assert node.end_lineno is not None # type: ignore[attr-defined]
-            return (node.lineno, node.end_lineno)
+            return (node.lineno, node.end_lineno) # type: ignore[attr-defined]
         else:
             return (node.lineno, node.lineno) # type: ignore[attr-defined]
     return None


### PR DESCRIPTION
Especially node spanning up really large amount of lines are taking forever in particular:

  - The mapping line -> Node takes forever to be constructed, so
      replace it by a pseudo-interval-tree like data structure, which
      stores only start/end of nodes and is lazy/caching.
  - Don't iterate on all the lines a node spans.

From local profiling with example present in
https://github.com/ipython/ipython/issues/13731,
this make the construction of self._nodes_by_line be negligible in the `__init__` function, vs taking ~50+ percent of the time.

That reduce my test example from 2.35s to 1.43s, with a interpreter startup of ~0.25s.