### PR TITLE
fix: check for pytest compatibility

### DIFF
--- a/executing/__init__.py
+++ b/executing/__init__.py
@@ -10,6 +10,9 @@ Get information about what a frame is currently doing. Typical usage:
 from collections import namedtuple
 _VersionInfo = namedtuple('_VersionInfo', ('major', 'minor', 'micro'))
 from .executing import Source, Executing, only, NotOneValueFound, cache, future_flags
+
+from ._pytest_utils import is_pytest_compatible
+
 try:
     from .version import __version__ # type: ignore[import]
     if "dev" in __version__:
@@ -22,4 +25,4 @@ else:
     __version_info__ = _VersionInfo(*map(int, __version__.split('.')))
 
 
-__all__ = ["Source"]
+__all__ = ["Source","is_pytest_compatible"]

--- a/executing/_pytest_utils.py
+++ b/executing/_pytest_utils.py
@@ -1,0 +1,16 @@
+import sys
+
+
+
+def is_pytest_compatible() -> bool:
+    """ returns true if executing can be used for expressions inside assert statements which are rewritten by pytest
+    """
+    if sys.version_info < (3, 11):
+        return False
+
+    try:
+        import pytest
+    except ImportError:
+        return False
+
+    return pytest.version_tuple >= (8, 3, 4)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+
+
+from typing import Optional, Sequence, Union
+from executing._pytest_utils import is_pytest_compatible
+import _pytest.assertion.rewrite as rewrite
+import importlib.machinery
+import types
+
+if not is_pytest_compatible():
+    original_find_spec = rewrite.AssertionRewritingHook.find_spec
+
+
+    def find_spec(
+        self,
+        name: str,
+        path: Optional[Sequence[Union[str, bytes]]] = None,
+        target: Optional[types.ModuleType] = None,
+    ) -> Optional[importlib.machinery.ModuleSpec]:
+
+        if name == "tests.test_main":
+            return None
+        return original_find_spec(self, name, path, target)
+
+
+    rewrite.AssertionRewritingHook.find_spec = find_spec

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,4 @@
 # -*- coding: utf-8 -*-
-"""
-
-assert rewriting will break executing
-PYTEST_DONT_REWRITE
-"""
 from __future__ import print_function, division
 import ast
 import contextlib

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -6,6 +6,7 @@ import sys
 from time import sleep
 
 import asttokens
+from executing._pytest_utils import is_pytest_compatible
 import pytest
 from littleutils import SimpleNamespace
 
@@ -123,6 +124,10 @@ def check_manual_linecache(filename):
 
 def test_exception_catching():
     frame = inspect.currentframe()
+
+    if is_pytest_compatible():
+        assert isinstance(Source.executing(frame).node,ast.Call)
+        return 
 
     executing.executing.TESTING = True  # this is already the case in all other tests
     # Sanity check that this operation usually raises an exception.


### PR DESCRIPTION
* added `executing.pytest_compatible` to allow other libraries to make use of executing and `assert ...` if available and to remove potential existing workarounds.
* `tests/test_main.py` is now executed with pytest assert rewriting if it is possible
* fixed the bug `tests/test_pytest.py` which lets the build fail on origin/master.

solves #91